### PR TITLE
End rumble if not playing sound.

### DIFF
--- a/ThumbAtro/main.py
+++ b/ThumbAtro/main.py
@@ -624,6 +624,7 @@ class PokerGame(Rectangle2DNode):
     def toggle_volume(self):
         if self.volume == .25:
             self.volume = 0
+            engine_io.rumble(0)
         else:
             self.volume = .25
         engine_audio.set_volume(self.volume)
@@ -646,6 +647,7 @@ class PokerGame(Rectangle2DNode):
         self.last_sound_time = None
         self.sound_play_duration = 0
         self.sound_start_time = None
+        engine_io.rumble(0)
 
     def tick(self, dt):
         if engine_io.MENU.is_just_pressed:


### PR DESCRIPTION
ThumbAtro has a bug in that it starts rumbling when it starts playing sounds, but doesn't stop rumbling when the sounds stop.  This PR adds stop-rumble code to existing stop-sound code.  Not tested.